### PR TITLE
Fixed bug on multilicensed packages

### DIFF
--- a/vrms_arch/license_finder.py
+++ b/vrms_arch/license_finder.py
@@ -152,13 +152,15 @@ class LicenseFinder(object):
         self.by_license = {}
 
         # packages with "custom" license
-        self.unknown_packages = []
+        self.unknown_packages = set()
 
         # packages with a known non-free license
-        self.nonfree_packages = []
+        self.nonfree_packages = set()
 
     def visit_db(self, db):
         pkgs = db.packages
+
+        free_pkgs = []
 
         for pkg in pkgs:
             for license in pkg.licenses:
@@ -168,13 +170,16 @@ class LicenseFinder(object):
                 else:
                     self.by_license[license].append(pkg)
 
-                if license not in FREE_LICENSES:
-                    if license in AMBIGUOUS_LICENSES:
-                        if (pkg not in self.unknown_packages):
-                            self.unknown_packages.append(pkg)
-                    else:
-                        if (pkg not in self.nonfree_packages):
-                            self.nonfree_packages.append(pkg)
+            free_licenses = list(filter(lambda x: x in FREE_LICENSES, pkg.licenses))
+            amb_licenses = list(filter(lambda x: x in AMBIGUOUS_LICENSES, pkg.licenses))
+
+            if len(free_licenses) > 0:
+                free_pkgs.append(pkg)
+                continue
+            elif len(amb_licenses) > 0:
+                self.unknown_packages.add(pkg)
+            else:
+                self.nonfree_packages.add(pkg)
 
     # Print all seen licenses in a convenient almost python list
     def list_all_licenses_as_python(self):


### PR DESCRIPTION
This patch fixes a bug by which vrms-arch didn't regarded as free packages those that are released under multiple licenses, one of which is a free license. 

If a project uses multiple licenses, and one of them is free, then the project must be considered free as the user will always have the right to redistribute that code under that free license. Therefore, my code has changed the behavior of vrms-arch so that if one free license is found for a package, that package is considered to be free.

I've also simplified the code by making some list elements sets. Python sets are lists that guarantee only one instance for each of its members. This simplifies the conditionals in the visit_db method.
