### PR TITLE
Added SIL OPEN FONT LICENSE

### DIFF
--- a/vrms_arch/license_finder.py
+++ b/vrms_arch/license_finder.py
@@ -58,6 +58,7 @@ FREE_LICENSES = [
     'Public Domain',
     'Python',
     'RUBY',
+    'SIL OPEN FONT LICENSE Version 1.1',
     'W3C',
     'ZLIB',
     'zlib',


### PR DESCRIPTION
according to the FSF this license is incompatible with the GPL,
but is free, and can only recomended for use on fonts.