### PR TITLE
Fixed an issue where having local files database would cause a crash

### DIFF
--- a/vrms
+++ b/vrms
@@ -43,8 +43,8 @@ h = pyalpm.Handle("/", "/var/lib/pacman")
 dbs_to_visit = []
 
 if(options.use_global_repos):
-    for d in os.listdir("/var/lib/pacman/sync"):
-        h.register_syncdb(os.path.splitext(d)[0], 0)
+    for d in set(os.path.splitext(f)[0] for f in os.listdir("/var/lib/pacman/sync")):
+        h.register_syncdb(d, 0)
     dbs_to_visit = h.get_syncdbs()
 else:
     # print("There are %d installed packages." % len(h.get_localdb()))


### PR DESCRIPTION
I have a local repo with a local files database. Which means that there are the files `myrepo.db` and `myrepo.files` in `/var/lib/pacman/sync`. This causes `register_syncdb` to be called twice on `myrepo`. alpm throws an error the second time.

This fix makes it so `register_syncdb` gets called on all unique repos only once.